### PR TITLE
V0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,12 +11,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Delete leftover `-wal` or `-shm` database artifacts when removing a bucket.
 - `config` YAML format configurations to supply complex configurations.
-- `concurrency_limit` to limit on the concurrent number of requests the underlying service can handle. Default `16`.
-- `read_only` to control whether this service/bucket is read-only. This is enforced at both the S3 API and SQLite (`query_only` pragma) level. Default: `false`.
-- `journal_mode` to control the SQLite `journal_mode` pragma. Default: `WAL`.
-- `synchronous` to control the SQLite `synchronous` pragma. Default: `NORMAL`.
-- `temp_store` to control the SQLite `temp_store` pragma. Default: `MEMORY`.
-- `cache_size` to control the SQLite `cache_size` pragma. Default: `67108864`.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.2.0] - 2023-07-05
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,30 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+- Delete leftover `-wal` or `-shm` database artifacts when removing a bucket.
+- `concurrency_limit` to limit on the concurrent number of requests the underlying service can handle. Default `16`.
+- `sqlite_journal_mode` to control the SQLite `journal_mode` pragma. Default: `WAL`.
+- `sqlite_synchronous` to control the SQLite `synchronous` pragma. Default: `NORMAL`.
+- `sqlite_temp_store` to control the SQLite `temp_store` pragma. Default: `MEMORY`.
+- `sqlite_cache_size` to control the SQLite `cache_size` pragma. Default: `67108864`.
+- `sqlite_query_only` to control the SQLite `query_only` pragma and prevent mutations to the database if set. Default: `false`.
+
+### Changed
+
+- SQLite tables are now created without `STRICT` mode enabled. This is to allow greater backward compatibility.
+
+## [0.1.0] - 2023-06-27
+
+### Added
+
+- An initial release proof-of-concept.
+- Works for the major get/put/delete/list operations and supports Cross-Origin Resource Sharing (CORS).
+- Supports presigned URLs.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,12 +10,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Delete leftover `-wal` or `-shm` database artifacts when removing a bucket.
+- `config` YAML format configurations to supply complex configurations.
 - `concurrency_limit` to limit on the concurrent number of requests the underlying service can handle. Default `16`.
-- `sqlite_journal_mode` to control the SQLite `journal_mode` pragma. Default: `WAL`.
-- `sqlite_synchronous` to control the SQLite `synchronous` pragma. Default: `NORMAL`.
-- `sqlite_temp_store` to control the SQLite `temp_store` pragma. Default: `MEMORY`.
-- `sqlite_cache_size` to control the SQLite `cache_size` pragma. Default: `67108864`.
-- `sqlite_query_only` to control the SQLite `query_only` pragma and prevent mutations to the database if set. Default: `false`.
+- `read_only` to control whether this service/bucket is read-only. This is enforced at both the S3 API and SQLite (`query_only` pragma) level. Default: `false`.
+- `journal_mode` to control the SQLite `journal_mode` pragma. Default: `WAL`.
+- `synchronous` to control the SQLite `synchronous` pragma. Default: `NORMAL`.
+- `temp_store` to control the SQLite `temp_store` pragma. Default: `MEMORY`.
+- `cache_size` to control the SQLite `cache_size` pragma. Default: `67108864`.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Correct verification of `Content-MD5` if provided by client.
+
 ### Added
 
 - Delete leftover `-wal` or `-shm` database artifacts when removing a bucket.
@@ -15,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - SQLite tables are now created without `STRICT` mode enabled. This is to allow greater backward compatibility.
+- Issue SQLite `VACUUM` command on startup.
 
 ## [0.1.0] - 2023-06-27
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1729,7 +1729,7 @@ checksum = "f91339c0467de62360649f8d3e185ca8de4224ff281f66000de5eb2a77a79041"
 
 [[package]]
 name = "s3ite"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1475,18 +1475,18 @@ checksum = "9b2a4787296e9989611394c33f193f676704af1686e70b8f8033ab5ba9a35a94"
 
 [[package]]
 name = "pin-project"
-version = "1.1.1"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e138fdd8263907a2b0e1b4e80b7e58c721126479b6e6eedfb1b402acea7b9bd"
+checksum = "030ad2bc4db10a8944cb0d837f158bdfec4d4a4873ab701a95046770d11f8842"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.1"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1fef411b303e3e12d534fb6e7852de82da56edd937d895125821fb7c09436c7"
+checksum = "ec2e072ecce94ec471b13398d5402c188e76ac03cf74dd1a975161b23a3f6d9c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1495,9 +1495,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.9"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0a7ae3ac2f1173085d398531c705756c94a4c56843785df85a60c1a0afac116"
+checksum = "4c40d25201921e5ff0c862a505c6557ea88568a4e3ace775ab55e93f2f4f9d57"
 
 [[package]]
 name = "pin-utils"
@@ -2023,9 +2023,9 @@ checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
 
 [[package]]
 name = "syn"
-version = "2.0.22"
+version = "2.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2efbeae7acf4eabd6bcdcbd11c92f45231ddda7539edc7806bd1a04a03b24616"
+checksum = "59fb7d6d8281a51045d62b8eb3a7d1ce347b76f312af50cd3dc0af39c87c1737"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "addr2line"
-version = "0.19.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a76fd60b23679b7d19bd066031410fb7e458ccc5e958eb5c325888ce4baedc97"
+checksum = "f4fa78e18c64fce05e902adecd7a5eed15a5e0a3439f7b0e169f0252214865e3"
 dependencies = [
  "gimli",
 ]
@@ -521,9 +521,9 @@ dependencies = [
 
 [[package]]
 name = "backtrace"
-version = "0.3.67"
+version = "0.3.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "233d376d6d185f2a3093e58f283f60f880315b6c60075b01f36b3b85154564ca"
+checksum = "4319208da049c43661739c5fade2ba182f09d1dc2299b32298d3a31692b17e12"
 dependencies = [
  "addr2line",
  "cc",
@@ -558,9 +558,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.3.2"
+version = "2.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6dbe3c979c178231552ecba20214a8272df4e09f232a87aef4320cf06539aded"
+checksum = "630be753d4e58660abd17930c71b647fe46c27ea6b63cc59e1e3851406972e42"
 
 [[package]]
 name = "block-buffer"
@@ -634,9 +634,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.3.8"
+version = "4.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9394150f5b4273a1763355bd1c2ec54cc5a2593f790587bcd6b2c947cfa9211"
+checksum = "384e169cc618c613d5e3ca6404dda77a8685a63e08660dcc64abaf7da7cb0c7a"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -645,13 +645,12 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.3.8"
+version = "4.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a78fbdd3cc2914ddf37ba444114bc7765bbdcb55ec9cbe6fa054f0137400717"
+checksum = "ef137bbe35aab78bdb468ccfba75a5f4d8321ae011d34063770780545176af2d"
 dependencies = [
  "anstream",
  "anstyle",
- "bitflags 1.3.2",
  "clap_lex",
  "strsim",
 ]
@@ -791,6 +790,12 @@ name = "either"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91"
+
+[[package]]
+name = "equivalent"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88bffebc5d80432c9b140ee17875ff173a8ab62faad5b257da912bd2f6c1c0a1"
 
 [[package]]
 name = "errno"
@@ -977,7 +982,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http",
- "indexmap",
+ "indexmap 1.9.3",
  "slab",
  "tokio",
  "tokio-util",
@@ -1024,15 +1029,6 @@ name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
-
-[[package]]
-name = "hermit-abi"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee512640fe35acbfb4bb779db6f0d80704c2cacfa2e39b601ef3e3f47d1ae4c7"
-dependencies = [
- "libc",
-]
 
 [[package]]
 name = "hermit-abi"
@@ -1188,6 +1184,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "indexmap"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5477fe2230a79769d8dc68e0eabf5437907c0457a5614a9e8dddb67f65eb65d"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.14.0",
+]
+
+[[package]]
 name = "instant"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1197,24 +1203,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "io-lifetimes"
-version = "1.0.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2"
-dependencies = [
- "hermit-abi 0.3.1",
- "libc",
- "windows-sys 0.48.0",
-]
-
-[[package]]
 name = "is-terminal"
-version = "0.4.7"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adcf93614601c8129ddf72e2d5633df827ba6551541c6d8c59520a371475be1f"
+checksum = "24fddda5af7e54bf7da53067d6e802dbcc381d0a8eef629df528e3ebf68755cb"
 dependencies = [
- "hermit-abi 0.3.1",
- "io-lifetimes",
+ "hermit-abi",
  "rustix",
  "windows-sys 0.48.0",
 ]
@@ -1259,9 +1253,9 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.3.8"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519"
+checksum = "09fc20d2ca12cb9f044c93e3bd6d32d523e6e2ec3db4f7b2939cd99026ecd3f0"
 
 [[package]]
 name = "lock_api"
@@ -1317,9 +1311,9 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.6.2"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b275950c28b37e794e8c55d88aeb5e139d0ce23fdbbeda68f8d7174abdf9e8fa"
+checksum = "e7810e0be55b428ada41041c41f32c9f1a42817901b4ccf45fa3d4b6561e74c7"
 dependencies = [
  "adler",
 ]
@@ -1385,11 +1379,11 @@ dependencies = [
 
 [[package]]
 name = "num_cpus"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fac9e2da13b5eb447a6ce3d392f23a29d8694bff781bf03a16cd9ac8697593b"
+checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
 dependencies = [
- "hermit-abi 0.2.6",
+ "hermit-abi",
  "libc",
 ]
 
@@ -1401,9 +1395,9 @@ checksum = "cf70ee2d9b1737d1836c20d9f8f96ec3901b2bf92128439db13237ddce9173a5"
 
 [[package]]
 name = "object"
-version = "0.30.4"
+version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03b4680b86d9cfafba8fc491dc9b6df26b68cf40e9e6cd73909194759a63c385"
+checksum = "8bda667d9f2b5051b8833f59f3bf748b28ef54f850f4fcb389a252aa383866d1"
 dependencies = [
  "memchr",
 ]
@@ -1481,18 +1475,18 @@ checksum = "9b2a4787296e9989611394c33f193f676704af1686e70b8f8033ab5ba9a35a94"
 
 [[package]]
 name = "pin-project"
-version = "1.1.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c95a7476719eab1e366eaf73d0260af3021184f18177925b07f54b30089ceead"
+checksum = "6e138fdd8263907a2b0e1b4e80b7e58c721126479b6e6eedfb1b402acea7b9bd"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39407670928234ebc5e6e580247dd567ad73a3578460c5990f9503df207e8f07"
+checksum = "d1fef411b303e3e12d534fb6e7852de82da56edd937d895125821fb7c09436c7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1544,9 +1538,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.28"
+version = "1.0.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9ab9c7eadfd8df19006f1cf1a4aed13540ed5cbc047010ece5826e10825488"
+checksum = "573015e8ab27661678357f27dc26460738fd2b6c86e46f386fde94cb5d913105"
 dependencies = [
  "proc-macro2",
 ]
@@ -1676,13 +1670,12 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.37.20"
+version = "0.38.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b96e891d04aa506a6d1f318d2771bcb1c7dfda84e126660ace067c9b474bb2c0"
+checksum = "fbc6396159432b5c8490d4e301d8c705f61860b8b6c863bf79942ce5401968f3"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.3.3",
  "errno",
- "io-lifetimes",
  "libc",
  "linux-raw-sys",
  "windows-sys 0.48.0",
@@ -1714,9 +1707,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pemfile"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d194b56d58803a43635bdc398cd17e383d6f71f9182b9a192c127ca42494a59b"
+checksum = "2d3987094b1d07b653b7dfdc3f70ce9a1da9c51ac18c1b06b662e4f9a0e9f4b2"
 dependencies = [
  "base64",
 ]
@@ -1753,7 +1746,9 @@ dependencies = [
  "rusqlite",
  "s3s",
  "s3s-aws",
+ "serde",
  "serde_json",
+ "serde_yaml",
  "thiserror",
  "time",
  "tokio",
@@ -1922,6 +1917,19 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serde_yaml"
+version = "0.9.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "452e67b9c20c37fa79df53201dc03839651086ed9bbe92b3ca585ca9fdaa7d85"
+dependencies = [
+ "indexmap 2.0.0",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
 ]
 
 [[package]]
@@ -2104,11 +2112,12 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.28.2"
+version = "1.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94d7b1cfd2aa4011f2de74c2c4c63665e27a71006b0a192dcd2710272e73dfa2"
+checksum = "532826ff75199d5833b9d2c5fe410f29235e25704ee5f0ef599fb51c21f4a4da"
 dependencies = [
  "autocfg",
+ "backtrace",
  "bytes",
  "libc",
  "mio",
@@ -2177,7 +2186,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "hdrhistogram",
- "indexmap",
+ "indexmap 1.9.3",
  "pin-project",
  "pin-project-lite",
  "rand",
@@ -2195,7 +2204,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8bd22a874a2d0b70452d5597b12c537331d49060824a95f49f108994f94aa4c"
 dependencies = [
- "bitflags 2.3.2",
+ "bitflags 2.3.3",
  "bytes",
  "futures-core",
  "futures-util",
@@ -2336,6 +2345,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "unsafe-libyaml"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1865806a559042e51ab5414598446a5871b561d21b6764f2eabb0dd481d880a6"
+
+[[package]]
 name = "untrusted"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2366,9 +2381,9 @@ checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
 name = "uuid"
-version = "1.3.4"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fa2982af2eec27de306107c027578ff7f423d65f7250e40ce0fea8f45248b81"
+checksum = "d023da39d1fde5a8a3fe1f3e01ca9632ada0a63e9797de55a879d6e2236277be"
 dependencies = [
  "getrandom",
 ]
@@ -2543,9 +2558,9 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.48.0"
+version = "0.48.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b1eb6f0cd7c80c79759c929114ef071b87354ce476d9d94271031c0497adfd5"
+checksum = "05d4b17490f70499f20b9e791dcf6a299785ce8af4d709018206dc5b4953e95f"
 dependencies = [
  "windows_aarch64_gnullvm 0.48.0",
  "windows_aarch64_msvc 0.48.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -124,9 +124,9 @@ checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
 
 [[package]]
 name = "async-trait"
-version = "0.1.69"
+version = "0.1.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b2d0f03b3640e3a630367e40c468cb7f309529c708ed1d88597047b0e7c6ef7"
+checksum = "79fa67157abdfd688a259b6648808757db9347af834624f27ec646da976aee5d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1032,9 +1032,9 @@ checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "hermit-abi"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fed44880c466736ef9a5c5b5facefb5ed0785676d0c02d612db14e54f0d84286"
+checksum = "443144c8cdadd93ebf52ddb4056d257f5b52c04d3c804e657d19eb73fc33668b"
 
 [[package]]
 name = "hex"
@@ -1898,9 +1898,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.99"
+version = "1.0.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46266871c240a00b8f503b877622fe33430b3c7d963bdc0f2adc511e54a1eae3"
+checksum = "0f1e14e89be7aa4c4b78bdbdc9eb5bf8517829a600ae8eaa39a6e1d960b5185c"
 dependencies = [
  "itoa",
  "ryu",
@@ -2040,18 +2040,18 @@ checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
 
 [[package]]
 name = "thiserror"
-version = "1.0.40"
+version = "1.0.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "978c9a314bd8dc99be594bc3c175faaa9794be04a5a5e153caba6915336cebac"
+checksum = "c16a64ba9387ef3fdae4f9c1a7f07a0997fce91985c0336f1ddc1822b3b37802"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.40"
+version = "1.0.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
+checksum = "d14928354b01c4d6a4f0e549069adef399a284e7995c7ccca94e8a07a5346c59"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -94,7 +94,7 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ca11d4be1bab0c8bc8734a9aa7bf4ee8316d462a08c6ac5052f888fef5b494b"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -104,7 +104,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "180abfa45703aebe0093f79badacc01b8fd4ea2e35118747e5811127f926e188"
 dependencies = [
  "anstyle",
- "windows-sys 0.48.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -124,9 +124,9 @@ checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
 
 [[package]]
 name = "async-trait"
-version = "0.1.68"
+version = "0.1.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9ccdd8f2a161be9bd5c023df56f1b2a0bd1d83872ae53b71a84a12c9bf6e842"
+checksum = "7b2d0f03b3640e3a630367e40c468cb7f309529c708ed1d88597047b0e7c6ef7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -805,7 +805,7 @@ checksum = "4bcfec3a70f97c962c307b2d2c56e358cf1d00b558d74262b5f929ee8cc7e73a"
 dependencies = [
  "errno-dragonfly",
  "libc",
- "windows-sys 0.48.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1210,14 +1210,14 @@ checksum = "24fddda5af7e54bf7da53067d6e802dbcc381d0a8eef629df528e3ebf68755cb"
 dependencies = [
  "hermit-abi",
  "rustix",
- "windows-sys 0.48.0",
+ "windows-sys",
 ]
 
 [[package]]
 name = "itoa"
-version = "1.0.6"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "453ad9f582a441959e5f0d088b02ce04cfe8d51a8eaf077f12ac6d3e94164ca6"
+checksum = "62b02a5381cc465bd3041d84623d0fa3b66738b52b8e2fc3bab8ad63ab032f4a"
 
 [[package]]
 name = "js-sys"
@@ -1326,7 +1326,7 @@ checksum = "927a765cd3fc26206e66b296465fa9d3e5ab003e651c1b3c060e7956d96b19d2"
 dependencies = [
  "libc",
  "wasi",
- "windows-sys 0.48.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1670,15 +1670,15 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.1"
+version = "0.38.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbc6396159432b5c8490d4e301d8c705f61860b8b6c863bf79942ce5401968f3"
+checksum = "aabcb0461ebd01d6b79945797c27f8529082226cb630a9865a71870ff63532a4"
 dependencies = [
  "bitflags 2.3.3",
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.48.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1716,9 +1716,9 @@ dependencies = [
 
 [[package]]
 name = "ryu"
-version = "1.0.13"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f91339c0467de62360649f8d3e185ca8de4224ff281f66000de5eb2a77a79041"
+checksum = "fe232bdf6be8c8de797b22184ee71118d63780ea42ac85b61d1baa6d3b782ae9"
 
 [[package]]
 name = "s3ite"
@@ -1824,11 +1824,11 @@ dependencies = [
 
 [[package]]
 name = "schannel"
-version = "0.1.21"
+version = "0.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "713cfb06c7059f3588fb8044c0fad1d09e3c01d225e25b9220dbfdcf16dbb1b3"
+checksum = "0c3733bf4cf7ea0880754e19cb5a462007c4a8c1914bff372ccc95b464f1df88"
 dependencies = [
- "windows-sys 0.42.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1878,18 +1878,18 @@ checksum = "bebd363326d05ec3e2f532ab7660680f3b02130d780c299bca73469d521bc0ed"
 
 [[package]]
 name = "serde"
-version = "1.0.164"
+version = "1.0.166"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e8c8cf938e98f769bc164923b06dce91cea1751522f46f8466461af04c9027d"
+checksum = "d01b7404f9d441d3ad40e6a636a7782c377d2abdbe4fa2440e2edcc2f4f10db8"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.164"
+version = "1.0.166"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9735b638ccc51c28bf6914d90a2e9725b377144fc612c49a611fddd1b631d68"
+checksum = "5dd83d6dde2b6b2d466e14d9d1acce8816dedee94f735eac6395808b3483c6d6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2127,7 +2127,7 @@ dependencies = [
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
- "windows-sys 0.48.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -2331,9 +2331,9 @@ checksum = "92888ba5573ff080736b3648696b70cafad7d250551175acbaa4e0385b3e1460"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.9"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b15811caf2415fb889178633e7724bad2509101cde276048e013b9def5e51fa0"
+checksum = "22049a19f4a68748a168c0fc439f9516686aa045927ff767eca0a85101fb6e73"
 
 [[package]]
 name = "unicode-normalization"
@@ -2534,21 +2534,6 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.42.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
-dependencies = [
- "windows_aarch64_gnullvm 0.42.2",
- "windows_aarch64_msvc 0.42.2",
- "windows_i686_gnu 0.42.2",
- "windows_i686_msvc 0.42.2",
- "windows_x86_64_gnu 0.42.2",
- "windows_x86_64_gnullvm 0.42.2",
- "windows_x86_64_msvc 0.42.2",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
@@ -2562,20 +2547,14 @@ version = "0.48.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05d4b17490f70499f20b9e791dcf6a299785ce8af4d709018206dc5b4953e95f"
 dependencies = [
- "windows_aarch64_gnullvm 0.48.0",
- "windows_aarch64_msvc 0.48.0",
- "windows_i686_gnu 0.48.0",
- "windows_i686_msvc 0.48.0",
- "windows_x86_64_gnu 0.48.0",
- "windows_x86_64_gnullvm 0.48.0",
- "windows_x86_64_msvc 0.48.0",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
 ]
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -2585,21 +2564,9 @@ checksum = "91ae572e1b79dba883e0d315474df7305d12f569b400fcf90581b06062f7e1bc"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2ef27e0d7bdfcfc7b868b317c1d32c641a6fe4629c171b8928c7b08d98d7cf3"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -2609,21 +2576,9 @@ checksum = "622a1962a7db830d6fd0a69683c80a18fda201879f0f447f065a3b7467daa241"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4542c6e364ce21bf45d69fdd2a8e455fa38d316158cfd43b3ac1c5b1b19f8e00"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -2633,21 +2588,9 @@ checksum = "ca2b8a661f7628cbd23440e50b05d705db3686f894fc9580820623656af974b1"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7896dbc1f41e08872e9d5e8f8baa8fdd2677f29468c4e156210174edc7f7b953"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "s3ite"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
-description = "An experimental S3 server based on sqlite"
+description = "An S3 server backed by SQLite"
 license = "MIT"
 readme = "../../README.md"
 repository = "https://github.com/seddonm1/s3ite"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,11 +14,11 @@ default = ["binary"]
 binary = ["tokio/full", "dep:clap", "dep:tracing-subscriber", "dep:hyper"]
 
 [dependencies]
-async-trait = "0.1.68"
+async-trait = "0.1.70"
 base64-simd = "0.8.0"
 bytes = "1.4.0"
 chrono = { version = "0.4.26", default-features = false, features = ["std", "clock"] }
-clap = { version = "4.3.8", optional = true, features = ["derive"] }
+clap = { version = "4.3.10", optional = true, features = ["derive"] }
 deadpool-sqlite = { version = "0.5.0", default-features = false, features = ["rt_tokio_1"] }
 rusqlite = { version = "0.28.0", features = ["time", "uuid", "bundled"] }
 futures = "0.3.28"
@@ -30,12 +30,12 @@ nugine-rust-utils = "0.3.1"
 numeric_cast = "0.2.1"
 path-absolutize = "3.1.0"
 s3s = "0.6.1"
-serde = { version = "1.0.164", features =["derive"] }
-serde_json = "1.0.99"
+serde = { version = "1.0.166", features =["derive"] }
+serde_json = "1.0.100"
 serde_yaml = "0.9.22"
-thiserror = "1.0.40"
+thiserror = "1.0.41"
 time = "0.3.22"
-tokio = { version = "1.29.0", features = ["fs", "io-util"] }
+tokio = { version = "1.29.1", features = ["fs", "io-util"] }
 tokio-util = { version = "0.7.8", features = ["io"] }
 tower = { version = "0.4.13", features = ["full"] }
 tower-http = { version = "0.4.1", features = ["cors"] }
@@ -52,7 +52,7 @@ aws-credential-types = { version = "0.55.3", features = ["test-util"] }
 aws-sdk-s3 = "0.28.0"
 once_cell = "1.18.0"
 s3s-aws =  "0.6.1"
-tokio = { version = "1.29.0", features = ["full"] }
+tokio = { version = "1.29.1", features = ["full"] }
 tracing-subscriber = { version = "0.3.17", features = ["env-filter", "time"] }
 
 [profile.release]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,22 +18,24 @@ async-trait = "0.1.68"
 base64-simd = "0.8.0"
 bytes = "1.4.0"
 chrono = { version = "0.4.26", default-features = false, features = ["std", "clock"] }
-clap = { version = "4.3.0", optional = true, features = ["derive"] }
+clap = { version = "4.3.8", optional = true, features = ["derive"] }
 deadpool-sqlite = { version = "0.5.0", default-features = false, features = ["rt_tokio_1"] }
 rusqlite = { version = "0.28.0", features = ["time", "uuid", "bundled"] }
 futures = "0.3.28"
 hex-simd = "0.8.0"
-hyper = { version = "0.14.26", optional = true, features = ["full"] }
+hyper = { version = "0.14.27", optional = true, features = ["full"] }
 md-5 = "0.10.5"
 mime = "0.3.17"
 nugine-rust-utils = "0.3.1"
 numeric_cast = "0.2.1"
 path-absolutize = "3.1.0"
 s3s = "0.6.1"
-serde_json = "1.0.96"
+serde = { version = "1.0.164", features =["derive"] }
+serde_json = "1.0.99"
+serde_yaml = "0.9.22"
 thiserror = "1.0.40"
-time = "0.3.21"
-tokio = { version = "1.28.2", features = ["fs", "io-util"] }
+time = "0.3.22"
+tokio = { version = "1.29.0", features = ["fs", "io-util"] }
 tokio-util = { version = "0.7.8", features = ["io"] }
 tower = { version = "0.4.13", features = ["full"] }
 tower-http = { version = "0.4.1", features = ["cors"] }
@@ -41,19 +43,18 @@ tracing = "0.1.37"
 tracing-error = "0.2.0"
 tracing-subscriber = { version = "0.3.17", optional = true, features = ["env-filter", "time"] }
 transform-stream = "0.3.0"
-uuid = { version = "1.3.3", features = ["v4"] }
+uuid = { version = "1.4.0", features = ["v4"] }
 
 [dev-dependencies]
 anyhow = { version = "1.0.71", features = ["backtrace"] }
 aws-config = "0.55.3"
 aws-credential-types = { version = "0.55.3", features = ["test-util"] }
 aws-sdk-s3 = "0.28.0"
-once_cell = "1.17.2"
+once_cell = "1.18.0"
 s3s-aws =  "0.6.1"
-tokio = { version = "1.28.2", features = ["full"] }
+tokio = { version = "1.29.0", features = ["full"] }
 tracing-subscriber = { version = "0.3.17", features = ["env-filter", "time"] }
 
 [profile.release]
 codegen-units = 1
 opt-level = 3
-debug = false

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,4 +5,5 @@ RUN cargo build --release --bin s3ite --features binary
 
 FROM gcr.io/distroless/cc
 COPY --from=build-env /app/target/release/s3ite /
-CMD ["./s3ite"]
+ENTRYPOINT ["./s3ite"]
+CMD ["--help"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM rust:1.70.0 as build-env
 WORKDIR /app
 COPY . /app
-RUN cargo build --release --bin s3ite --features binary
+RUN cargo build -C target-feature="+avx2" --release --bin s3ite --features binary
 
 FROM gcr.io/distroless/cc
 COPY --from=build-env /app/target/release/s3ite /

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM rust:1.70.0 as build-env
 WORKDIR /app
 COPY . /app
-RUN cargo build -C target-feature="+avx2" --release --bin s3ite --features binary
+RUN cargo build --release --bin s3ite --features binary
 
 FROM gcr.io/distroless/cc
 COPY --from=build-env /app/target/release/s3ite /

--- a/README.md
+++ b/README.md
@@ -10,6 +10,38 @@ This crate was built to test the feasiblity of using SQLite as an alternative to
 
 This concept is backed by benchmarks from SQLite showing that it can be [faster than filesytems](https://www.sqlite.org/fasterthanfs.html) for certain data access patterns.
 
+## Configuration
+
+`s3ite` has two methods of configuration: a `yaml` configuration file or command-line-interface. The `yaml` configuration (provided via the `--config` argument) allows options to be specified at the `bucket` level whereas the command-line-interface provides only service-level configurations.
+
+This structure is heirarchical where:
+
+### Bucket Level Configuration
+
+`bucket` level configurations will take precedence over the `sevice` level configuration.
+
+This design allows setting specific `bucket` level permissions like below where the `mybucket` bucket will be `read-only` and all other buckets will be writable.
+
+```yaml
+root: .
+host: 0.0.0.0
+port: 8014
+permissive_cors: true
+concurrency: 16
+read_only: false
+buckets:
+  mybucket:
+    read_only: true
+```
+
+### Command-Line Service Configuration
+
+Command-line-interface arguments will take precedence over any `service` level configuration like below where the default `root` value `.` is overridden with `/data`.
+
+```bash
+s3ite --root /data
+```
+
 ## Architecture
 
 Each bucket is saved to a separate `.sqlite3` database named after the bucket name. The [smithy](https://github.com/awslabs/smithy) generated bindings for `s3` are then mapped to the correct SQL calls against a very simple schema that is designed to be human accessible.

--- a/README.md
+++ b/README.md
@@ -10,41 +10,11 @@ This crate was built to test the feasiblity of using SQLite as an alternative to
 
 This concept is backed by benchmarks from SQLite showing that it can be [faster than filesytems](https://www.sqlite.org/fasterthanfs.html) for certain data access patterns.
 
-## Configuration
-
-`s3ite` has two methods of configuration: a `yaml` configuration file or command-line-interface. The `yaml` configuration (provided via the `--config` argument) allows options to be specified at the `bucket` level whereas the command-line-interface provides only service-level configurations.
-
-This structure is heirarchical where:
-
-### Bucket Level Configuration
-
-`bucket` level configurations will take precedence over the `sevice` level configuration.
-
-This design allows setting specific `bucket` level permissions like below where the `mybucket` bucket will be `read-only` and all other buckets will be writable.
-
-```yaml
-root: .
-host: 0.0.0.0
-port: 8014
-permissive_cors: true
-concurrency: 16
-read_only: false
-buckets:
-  mybucket:
-    read_only: true
-```
-
-### Command-Line Service Configuration
-
-Command-line-interface arguments will take precedence over any `service` level configuration like below where the default `root` value `.` is overridden with `/data`.
-
-```bash
-s3ite --root /data
-```
-
 ## Architecture
 
-Each bucket is saved to a separate `.sqlite3` database named after the bucket name. The [smithy](https://github.com/awslabs/smithy) generated bindings for `s3` are then mapped to the correct SQL calls against a very simple schema that is designed to be human accessible.
+Each `bucket` is saved to a separate `.sqlite3` database named after the `bucket` name. The [smithy](https://github.com/awslabs/smithy) generated bindings for `s3` are then mapped to the correct SQL calls against a very simple schema that is designed to be human accessible.
+
+`content-md5` verification (if available) and SQLite [database transactions](https://sqlite.org/transactional.html) are used to prevent data loss or partial updates.
 
 ### Data
 
@@ -86,6 +56,64 @@ CREATE TABLE IF NOT EXISTS multipart_upload_part (
 ) STRICT;
 ```
 
+## Configuration
+
+`s3ite` provides configuration options at the `service` level (i.e. the global level that apply to all buckets or control the API behavior) or at the `bucket` level for changing specific bucket behavior. To set them `sqlite` has two methods of configuration: a `yaml` configuration file or the command-line-interface.
+
+The `yaml` configuration (provided via the `--config` argument) differs from the `command-line-interface` options in that it allows parameters be specified at the `service` and `bucket` levels whereas the `command-line-interface` provides only `service` level configuration.
+
+The options are:
+
+- `root`: The base path where the `.sqlite3` files will be created.
+- `host`: The IP address to listen on for this service.
+- `port`: The port to listen on for this service.
+- `access_key`: The access key ID that is used to authenticate for this service.
+- `secret_key`: The secret access key that is used to authenticate for this service.
+- `concurrency_limit`: Enforces a limit on the concurrent number of requests the underlying service can handle. This can be tuned depending on infrastructure as SSD/HDD will handle resource contention very differently.
+- `permissive_cors`: Allow permissive Cross-Origin Resource Sharing (CORS) requests. This can be enabled to allow users to access this service from a web service running on a different host.
+- `domain_name`: The domain to use to allow parsing virtual-hosted-style requests.
+- `read_only`: Prevent mutations to any of the databases connected to this service.
+- `journal_mode`: Controls the default SQLite [journal_mode](https://www.sqlite.org/pragma.html#pragma_journal_mode) pragma.
+- `synchronous`: Controls the default SQLite [synchronous](https://www.sqlite.org/pragma.html#pragma_synchronous) pragma.
+- `temp_store`: Controls the default SQLite [temp_store](https://www.sqlite.org/pragma.html#pragma_temp_store) pragma.
+- `cache_size`: Controls the default SQLite [cache_size](https://www.sqlite.org/pragma.html#pragma_cache_size) pragma.
+
+This structure is heirarchical where:
+
+### Command-Line Service Configuration
+
+`command-line-interface` arguments will take precedence over any `service` level configuration like below where the default `root` value `.` is overridden with `/data`.
+
+```bash
+s3ite --root /data
+```
+
+### Bucket Level Configuration
+
+If set, `bucket` level configurations will take precedence over the `service` level configurations.
+
+This design allows setting specific `bucket` level configurations like below where the `mybucket` bucket will be set to `read-only` on startup and all other buckets will be writable. An error will be raised if any specified bucket does not exist (in this case and error is raised if `mybucket.sqlite3` is not found and accessible).
+
+```yaml
+root: /data
+host: 0.0.0.0
+port: 8014
+access_key: AKIAIOSFODNN7EXAMPLE
+secret_key: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
+permissive_cors: true
+concurrency: 16
+read_only: false
+journal_mode: WAL
+synchronous: NORMAL
+temp_store: MEMORY
+cache_size: 67108864
+buckets:
+  mybucket:
+    read_only: true
+    sqlite:
+      cache_size: 134217728
+```
+
 ## Docker
 
 ```bash
@@ -94,7 +122,8 @@ docker run --rm \
 -v $(pwd)/test:/data \
 -p 8014:8014 \
 s3ite:latest \
-./s3ite /data \
+./s3ite \
+--root /data \
 --host 0.0.0.0 \
 --port 8014 \
 --concurrency_limit 16 \
@@ -120,6 +149,6 @@ cargo install --path .
 ## Run
 
 ```bash
-s3ite . --host 0.0.0.0 --port 8014 --access-key AKIAIOSFODNN7EXAMPLE --secret-key wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
+s3ite --root . --host 0.0.0.0 --port 8014 --access-key AKIAIOSFODNN7EXAMPLE --secret-key wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
 ```
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ CREATE TABLE IF NOT EXISTS data (
     metadata        TEXT,
     last_modified   TEXT NOT NULL,
     md5             TEXT
-) STRICT;
+);
 ```
 
 ### Multipart Uploads
@@ -42,7 +42,7 @@ CREATE TABLE IF NOT EXISTS multipart_upload (
     key                     TEXT NOT NULL,
     last_modified           TEXT NOT NULL,
     access_key              TEXT
-) STRICT;
+);
 
 CREATE TABLE IF NOT EXISTS multipart_upload_part (
     upload_id               BLOB NOT NULL,
@@ -53,7 +53,7 @@ CREATE TABLE IF NOT EXISTS multipart_upload_part (
     md5                     TEXT,
     PRIMARY KEY (upload_id, part_number),
     FOREIGN KEY (upload_id) REFERENCES multipart_upload (upload_id) ON DELETE CASCADE
-) STRICT;
+);
 ```
 
 ## Configuration

--- a/README.md
+++ b/README.md
@@ -54,6 +54,23 @@ CREATE TABLE IF NOT EXISTS multipart_upload_part (
 ) STRICT;
 ```
 
+## Docker
+
+```bash
+docker run --rm \
+-e RUST_LOG=info \
+-v $(pwd)/test:/data \
+-p 8014:8014 \
+s3ite:latest \
+./s3ite /data \
+--host 0.0.0.0 \
+--port 8014 \
+--concurrency_limit 16 \
+--access-key AKIAIOSFODNN7EXAMPLE \
+--secret-key wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
+```
+
+
 ## Build
 
 This code can be used as a library or a standalone binary. To build the binary:
@@ -74,17 +91,3 @@ cargo install --path .
 s3ite . --host 0.0.0.0 --port 8014 --access-key AKIAIOSFODNN7EXAMPLE --secret-key wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
 ```
 
-## Docker
-
-```bash
-docker run --rm \
--e RUST_LOG=info \
--v $(pwd)/test:/data \
--p 8014:8014 \
-s3ite:latest \
-./s3ite /data \
---host 0.0.0.0 \
---port 8014 \
---access-key AKIAIOSFODNN7EXAMPLE \
---secret-key wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
-```

--- a/src/config.rs
+++ b/src/config.rs
@@ -8,20 +8,26 @@ use std::{
 };
 
 #[derive(Clone, Deserialize, Debug)]
-
+#[serde(deny_unknown_fields)]
 pub struct Config {
     /// The base path where the `.sqlite3` files will be created.
     /// All `.sqlite3` files at this path will be loaded at startup and exposed via this service.
     #[serde(default = "default_root")]
     pub root: PathBuf,
 
-    /// The ip address to listen on for this service. Use `0.0.0.0` to listen on all interfaces.
+    /// The IP address to listen on for this service. Use `0.0.0.0` to listen on all interfaces.
     #[serde(default = "default_host")]
     pub host: IpAddr,
 
     /// The port to listen on for this service.
     #[serde(default = "default_port")]
     pub port: u16,
+
+    /// The access key ID that is used to authenticate for this service.
+    pub access_key: Option<String>,
+
+    /// The secret access key that is used to authenticate for this service.
+    pub secret_key: Option<String>,
 
     #[serde(default = "default_concurrency_limit")]
     /// Enforces a limit on the concurrent number of requests the underlying service can handle.
@@ -41,9 +47,10 @@ pub struct Config {
     pub read_only: bool,
 
     /// Service level SQLite configurations
-    #[serde(default = "default_pragmas")]
+    #[serde(flatten, default = "default_pragmas")]
     pub sqlite: Pragmas,
 
+    /// Bucket specific configurations
     #[serde(default = "HashMap::new")]
     pub buckets: HashMap<String, Bucket>,
 }
@@ -54,6 +61,8 @@ impl Default for Config {
             root: default_root(),
             host: default_host(),
             port: default_port(),
+            access_key: None,
+            secret_key: None,
             concurrency_limit: default_concurrency_limit(),
             permissive_cors: default_permissive_cors(),
             read_only: default_read_only(),

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,0 +1,266 @@
+use clap::ValueEnum;
+use serde::Deserialize;
+use std::{
+    collections::HashMap,
+    net::{IpAddr, Ipv4Addr},
+    path::PathBuf,
+    str::FromStr,
+};
+
+#[derive(Clone, Deserialize, Debug)]
+
+pub struct Config {
+    /// The base path where the `.sqlite3` files will be created.
+    /// All `.sqlite3` files at this path will be loaded at startup and exposed via this service.
+    #[serde(default = "default_root")]
+    pub root: PathBuf,
+
+    /// The ip address to listen on for this service. Use `0.0.0.0` to listen on all interfaces.
+    #[serde(default = "default_host")]
+    pub host: IpAddr,
+
+    /// The port to listen on for this service.
+    #[serde(default = "default_port")]
+    pub port: u16,
+
+    #[serde(default = "default_concurrency_limit")]
+    /// Enforces a limit on the concurrent number of requests the underlying service can handle.
+    /// This can be tuned depending on infrastructure as SSD/HDD will deal with resource contention very differently.
+    pub concurrency_limit: u16,
+
+    /// Allow permissive Cross-Origin Resource Sharing (CORS) requests.
+    /// This can be enabled to allow users to access this service from a web service running on a different host.
+    #[serde(default = "default_permissive_cors")]
+    pub permissive_cors: bool,
+
+    /// The domain to use to allow parsing virtual-hosted-style requests.
+    pub domain_name: Option<String>,
+
+    /// If this service should be read-only
+    #[serde(default = "default_read_only")]
+    pub read_only: bool,
+
+    /// Service level SQLite configurations
+    #[serde(default = "default_pragmas")]
+    pub sqlite: Pragmas,
+
+    #[serde(default = "HashMap::new")]
+    pub buckets: HashMap<String, Bucket>,
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self {
+            root: default_root(),
+            host: default_host(),
+            port: default_port(),
+            concurrency_limit: default_concurrency_limit(),
+            permissive_cors: default_permissive_cors(),
+            read_only: default_read_only(),
+            domain_name: None,
+            sqlite: default_pragmas(),
+            buckets: HashMap::default(),
+        }
+    }
+}
+
+impl Config {
+    #[must_use]
+    pub fn read_only(&self, bucket: Option<&str>) -> bool {
+        bucket
+            .and_then(|bucket| self.buckets.get(bucket).and_then(|bucket| bucket.read_only))
+            .unwrap_or(self.read_only)
+    }
+
+    #[must_use]
+    pub fn journal_mode(&self, bucket: Option<&str>) -> JournalMode {
+        bucket
+            .and_then(|bucket| {
+                self.buckets.get(bucket).and_then(|bucket| {
+                    bucket
+                        .sqlite
+                        .as_ref()
+                        .and_then(|sqlite| sqlite.journal_mode)
+                })
+            })
+            .unwrap_or(self.sqlite.journal_mode)
+    }
+
+    #[must_use]
+    pub fn synchronous(&self, bucket: Option<&str>) -> Synchronous {
+        bucket
+            .and_then(|bucket| {
+                self.buckets
+                    .get(bucket)
+                    .and_then(|bucket| bucket.sqlite.as_ref().and_then(|sqlite| sqlite.synchronous))
+            })
+            .unwrap_or(self.sqlite.synchronous)
+    }
+
+    #[must_use]
+    pub fn temp_store(&self, bucket: Option<&str>) -> TempStore {
+        bucket
+            .and_then(|bucket| {
+                self.buckets
+                    .get(bucket)
+                    .and_then(|bucket| bucket.sqlite.as_ref().and_then(|sqlite| sqlite.temp_store))
+            })
+            .unwrap_or(self.sqlite.temp_store)
+    }
+
+    #[must_use]
+    pub fn cache_size(&self, bucket: Option<&str>) -> u32 {
+        bucket
+            .and_then(|bucket| {
+                self.buckets
+                    .get(bucket)
+                    .and_then(|bucket| bucket.sqlite.as_ref().and_then(|sqlite| sqlite.cache_size))
+            })
+            .unwrap_or(self.sqlite.cache_size)
+    }
+
+    #[must_use]
+    pub fn to_sql(&self, bucket: Option<&str>) -> String {
+        format!(
+            "
+            PRAGMA journal_mode={:?};
+            PRAGMA synchronous={:?};
+            PRAGMA temp_store={:?};
+            PRAGMA cache_size=-{};
+            PRAGMA query_only={};
+            PRAGMA foreign_keys=true;
+        ",
+            self.journal_mode(bucket),
+            self.synchronous(bucket),
+            self.temp_store(bucket),
+            self.cache_size(bucket),
+            self.read_only(bucket),
+        )
+    }
+}
+
+#[derive(Clone, Deserialize, Debug)]
+pub struct Pragmas {
+    /// Controls the SQLite `journal_mode` flag pragma.
+    #[serde(default = "default_journal_mode")]
+    pub journal_mode: JournalMode,
+
+    /// Controls the SQLite `synchronous` pragma.
+    #[serde(default = "default_synchronous")]
+    pub synchronous: Synchronous,
+
+    /// Controls the SQLite `temp_store` pragma.
+    #[serde(default = "default_temp_store")]
+    pub temp_store: TempStore,
+
+    /// Controls the SQLite `cache_size` pragma in kilobytes.
+    #[serde(default = "default_cache_size")]
+    pub cache_size: u32,
+}
+
+impl Default for Pragmas {
+    fn default() -> Self {
+        Self {
+            journal_mode: JournalMode::WAL,
+            synchronous: Synchronous::NORMAL,
+            temp_store: TempStore::MEMORY,
+            cache_size: 67_108_864,
+        }
+    }
+}
+
+#[derive(Clone, Deserialize, Debug)]
+pub struct Bucket {
+    /// If this bucket should be read-only
+    pub read_only: Option<bool>,
+
+    /// Bucket level SQLite configurations
+    pub sqlite: Option<BucketPragmas>,
+}
+
+#[derive(Clone, Deserialize, Debug)]
+pub struct BucketPragmas {
+    /// Controls the SQLite `journal_mode` flag pragma.
+    pub journal_mode: Option<JournalMode>,
+
+    /// Controls the SQLite `synchronous` pragma.
+    pub synchronous: Option<Synchronous>,
+
+    /// Controls the SQLite `temp_store` pragma.
+    pub temp_store: Option<TempStore>,
+
+    /// Controls the SQLite `cache_size` pragma in kilobytes.
+    pub cache_size: Option<u32>,
+}
+
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Deserialize, ValueEnum)]
+pub enum JournalMode {
+    DELETE,
+    TRUNCATE,
+    PERSIST,
+    MEMORY,
+    #[default]
+    WAL,
+    OFF,
+}
+
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Deserialize, ValueEnum)]
+pub enum Synchronous {
+    OFF,
+    #[default]
+    NORMAL,
+    FULL,
+    EXTRA,
+}
+
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Deserialize, ValueEnum)]
+pub enum TempStore {
+    DEFAULT,
+    FILE,
+    #[default]
+    MEMORY,
+}
+
+fn default_root() -> PathBuf {
+    PathBuf::from_str(".").unwrap()
+}
+
+fn default_host() -> IpAddr {
+    IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0))
+}
+
+fn default_port() -> u16 {
+    8014
+}
+
+fn default_concurrency_limit() -> u16 {
+    16
+}
+
+fn default_permissive_cors() -> bool {
+    true
+}
+
+fn default_read_only() -> bool {
+    false
+}
+
+fn default_pragmas() -> Pragmas {
+    Pragmas::default()
+}
+
+fn default_journal_mode() -> JournalMode {
+    JournalMode::default()
+}
+
+fn default_synchronous() -> Synchronous {
+    Synchronous::default()
+}
+
+fn default_temp_store() -> TempStore {
+    TempStore::default()
+}
+
+fn default_cache_size() -> u32 {
+    67_108_864
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -33,7 +33,10 @@ where
 
 impl From<Error> for S3Error {
     fn from(e: Error) -> Self {
-        S3Error::with_source(S3ErrorCode::InternalError, e.source)
+        match e.source.downcast::<S3Error>() {
+            Ok(s3error) => *s3error,
+            Err(source) => S3Error::with_source(S3ErrorCode::InternalError, source),
+        }
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,9 +12,11 @@
 #[macro_use]
 mod error;
 
+mod config;
 mod s3;
 mod sqlite;
 mod utils;
 
+pub use self::config::*;
 pub use self::error::*;
 pub use self::sqlite::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,4 +17,4 @@ mod sqlite;
 mod utils;
 
 pub use self::error::*;
-pub use self::sqlite::Sqlite;
+pub use self::sqlite::*;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,11 +1,11 @@
 #![forbid(unsafe_code)]
 #![deny(clippy::all, clippy::pedantic)]
 
-use s3ite::Result;
-use s3ite::Sqlite;
+use s3ite::{JournalMode, Pragmas, Result, Sqlite, Synchronous, TempStore};
 
 use s3s::auth::SimpleAuth;
 use s3s::service::S3ServiceBuilder;
+use tower::limit::ConcurrencyLimitLayer;
 use tower::make::Shared;
 use tower::ServiceBuilder;
 use tower_http::cors::CorsLayer;
@@ -20,27 +20,75 @@ use hyper::server::Server;
 use tracing::info;
 use tracing_subscriber::EnvFilter;
 
-#[derive(Debug, Parser)]
+#[derive(Parser)]
+#[command(author, version, about, long_about = None)]
 struct Opt {
-    #[clap(long, default_value = "localhost")]
+    #[clap(long, default_value = "127.0.0.1")]
+    /// The ip address to listen on for this service. Use `0.0.0.0` to listen on all interfaces.
     host: IpAddr,
 
     #[clap(long, default_value = "8014")]
+    /// The port to listen on for this service.
     port: u16,
 
     #[clap(long, default_value_t = true)]
+    /// Allow permissive Cross-Origin Resource Sharing (CORS) requests.
+    /// This can be enabled to allow users to access this service from a web service running on a different host.
     permissive_cors: bool,
 
-    #[clap(long, requires("secret-key"))]
+    #[clap(long, requires = "secret_key")]
+    /// The access key ID that is used to authenticate for this service.
     access_key: Option<String>,
 
-    #[clap(long, requires("access-key"))]
+    #[clap(long, requires = "access_key")]
+    /// The secret access key that is used to authenticate for this service.
     secret_key: Option<String>,
 
     #[clap(long)]
+    /// The domain to use to allow parsing virtual-hosted-style requests.
     domain_name: Option<String>,
 
+    #[clap(long, default_value_t = 16)]
+    /// Enforces a limit on the concurrent number of requests the underlying service can handle.
+    /// This can be tuned depending on infrastructure as SSD/HDD will deal with resource contention very differently.
+    concurrency_limit: usize,
+
+    /// Controls the SQLite `journal_mode` flag pragma.
+    #[clap(long, default_value = "wal")]
+    sqlite_journal_mode: JournalMode,
+
+    #[clap(long, default_value = "normal")]
+    /// Controls the SQLite `synchronous` pragma.
+    sqlite_synchronous: Synchronous,
+
+    #[clap(long, default_value = "memory")]
+    /// Controls the SQLite `temp_store` pragma.
+    sqlite_temp_store: TempStore,
+
+    #[clap(long, default_value_t = 67108864)]
+    /// Controls the SQLite `cache_size` pragma in kilobytes.
+    sqlite_cache_size: u32,
+
+    #[clap(long, default_value_t = false)]
+    /// Controls the SQLite `query_only` pragma. Can be used to prevent database mutation.
+    sqlite_query_only: bool,
+
+    /// The base path where the `.sqlite3` files will be created.
+    /// All `.sqlite3` files at this path will be loaded at startup and exposed via this service.
     root: PathBuf,
+}
+
+impl From<&Opt> for Pragmas {
+    fn from(val: &Opt) -> Self {
+        Self {
+            journal_mode: val.sqlite_journal_mode,
+            synchronous: val.sqlite_synchronous,
+            temp_store: val.sqlite_temp_store,
+            cache_size: val.sqlite_cache_size,
+            query_only: val.sqlite_query_only,
+            foreign_keys: true,
+        }
+    }
 }
 
 #[tokio::main]
@@ -55,15 +103,15 @@ async fn main() -> Result {
     let listener = TcpListener::bind(addr)?;
 
     // Setup S3 provider
-    let sqlite = Sqlite::new(opt.root).await?;
+    let sqlite = Sqlite::new(&opt.root, Pragmas::from(&opt)).await?;
 
     // Setup S3 service
     let s3_service = {
         let mut s3 = S3ServiceBuilder::new(sqlite);
 
         // Enable authentication
-        if let (Some(ak), Some(sk)) = (opt.access_key, opt.secret_key) {
-            s3.set_auth(SimpleAuth::from_single(ak, sk));
+        if let (Some(access_key), Some(secret_key)) = (opt.access_key, opt.secret_key) {
+            s3.set_auth(SimpleAuth::from_single(access_key, secret_key));
         }
 
         // Enable parsing virtual-hosted-style requests
@@ -80,13 +128,18 @@ async fn main() -> Result {
         let service = Shared::new(
             ServiceBuilder::new()
                 .layer(CorsLayer::very_permissive())
+                .layer(ConcurrencyLimitLayer::new(opt.concurrency_limit))
                 .service(s3_service),
         );
         let server = Server::from_tcp(listener)?.serve(service);
         info!("server is running at http://{addr}");
         server.with_graceful_shutdown(shutdown_signal()).await?;
     } else {
-        let service = Shared::new(ServiceBuilder::new().service(s3_service));
+        let service = Shared::new(
+            ServiceBuilder::new()
+                .layer(ConcurrencyLimitLayer::new(opt.concurrency_limit))
+                .service(s3_service),
+        );
         let server = Server::from_tcp(listener)?.serve(service);
         info!("server is running at http://{addr}");
         server.with_graceful_shutdown(shutdown_signal()).await?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -35,7 +35,7 @@ struct Opt {
     config: Option<PathBuf>,
 
     #[clap(long)]
-    /// The ip address to listen on for this service. Use `0.0.0.0` to listen on all interfaces.
+    /// The IP address to listen on for this service. Use `0.0.0.0` to listen on all interfaces.
     host: Option<IpAddr>,
 
     #[clap(long)]
@@ -111,6 +111,12 @@ async fn main() -> Result {
     if let Some(port) = opt.port {
         config.port = port;
     }
+    if let Some(access_key) = opt.access_key {
+        config.access_key = Some(access_key);
+    }
+    if let Some(secret_key) = opt.secret_key {
+        config.secret_key = Some(secret_key);
+    }
     if let Some(permissive_cors) = opt.permissive_cors {
         config.permissive_cors = permissive_cors;
     }
@@ -148,7 +154,7 @@ async fn main() -> Result {
         let mut s3 = S3ServiceBuilder::new(sqlite);
 
         // Enable authentication
-        if let (Some(access_key), Some(secret_key)) = (opt.access_key, opt.secret_key) {
+        if let (Some(access_key), Some(secret_key)) = (config.access_key, config.secret_key) {
             s3.set_auth(SimpleAuth::from_single(access_key, secret_key));
         }
 

--- a/src/sqlite.rs
+++ b/src/sqlite.rs
@@ -99,6 +99,7 @@ impl Sqlite {
                                     "
                                     PRAGMA analysis_limit=1000;
                                     PRAGMA optimize;
+                                    VACUUM;
                                     ",
                                 )?;
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -30,6 +30,11 @@ pub fn hex(input: impl AsRef<[u8]>) -> String {
     hex_simd::encode_to_string(input, hex_simd::AsciiCase::Lower)
 }
 
+pub fn base64(input: impl AsRef<[u8]>) -> String {
+    let base64 = base64_simd::STANDARD;
+    base64.encode_to_string(input)
+}
+
 // Helper function to return a comma-separated sequence of `?`.
 // - `repeat_vars(0) => panic!(...)`
 // - `repeat_vars(1) => "?"`

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -4,9 +4,8 @@
     clippy::must_use_candidate, //
 )]
 
-use md5::Digest;
-use md5::Md5;
-use s3ite::Sqlite;
+use md5::{Digest, Md5};
+use s3ite::{Pragmas, Sqlite};
 use s3s::auth::SimpleAuth;
 use s3s::service::S3ServiceBuilder;
 
@@ -63,7 +62,7 @@ impl TestContext {
 
         // Setup S3 provider
         fs::create_dir_all(FS_ROOT).unwrap();
-        let fs = Sqlite::new(FS_ROOT).await.unwrap();
+        let fs = Sqlite::new(FS_ROOT, Pragmas::default()).await.unwrap();
 
         // Setup S3 service
         let service = {

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -140,8 +140,9 @@ async fn delete_bucket(c: &Client, bucket: &str) -> Result<()> {
     Ok(())
 }
 
-pub fn hex(input: impl AsRef<[u8]>) -> String {
-    hex_simd::encode_to_string(input, hex_simd::AsciiCase::Lower)
+pub fn base64(input: impl AsRef<[u8]>) -> String {
+    let base64 = base64_simd::STANDARD;
+    base64.encode_to_string(input)
 }
 
 #[tokio::test]
@@ -195,7 +196,7 @@ async fn test_single_object() -> Result<()> {
     let content_bytes = content.as_bytes();
     let mut md5_hash = Md5::new();
     md5_hash.update(content_bytes);
-    let content_md5 = hex(md5_hash.finalize());
+    let content_md5 = base64(md5_hash.finalize());
 
     create_bucket(&context, &bucket).await?;
 
@@ -240,7 +241,7 @@ async fn test_multipart() -> Result<()> {
     let content_bytes = content.as_bytes();
     let mut md5_hash = Md5::new();
     md5_hash.update(content_bytes);
-    let content_md5 = hex(md5_hash.finalize());
+    let content_md5 = base64(md5_hash.finalize());
 
     let upload_id = {
         let result = context


### PR DESCRIPTION
### Fixed

- Correct verification of `Content-MD5` if provided by client.

### Added

- Delete leftover `-wal` or `-shm` database artifacts when removing a bucket.
- `config` YAML format configurations to supply complex configurations.

### Changed

- SQLite tables are now created without `STRICT` mode enabled. This is to allow greater backward compatibility.
- Issue SQLite `VACUUM` command on startup.