### PR TITLE
V0.3.0

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.70.0
+FROM rust:1.71.0
 
 RUN rustup component add rustfmt &&\
     rustup component add clippy

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.3.0] - 2023-07-16
 
 ## Changed
 
-- split the core data table into `metadata` and `data`.
+- Split the core data table into `data` and `metadata`.
+- Add a simple garbage collection task to clean up any redundant state. E.g. from a client cancelling an in-progress `list_objects` task.
+- Remove SQLite `VACUUM` command on startup due to potentially large memory usage.
+
+### Fixed
+
+- Snapshot database `metadata` state on `list_objects` so that deletes will remove all objects.
 
 ## [0.2.0] - 2023-07-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+## Changed
+
+- split the core data table into `metadata` and `data`.
+
 ## [0.2.0] - 2023-07-05
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -39,9 +39,9 @@ dependencies = [
 
 [[package]]
 name = "allocator-api2"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56fc6cf8dc8c4158eed8649f9b8b0ea1518eb62b544fe9490d66fa0b349eafe9"
+checksum = "0942ffc6dcaadf03badf6e6a2d0228460359d5e34b57ccdc720b7382dfbd5ec5"
 
 [[package]]
 name = "android-tzdata"
@@ -109,9 +109,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.71"
+version = "1.0.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c7d0618f0e0b7e8ff11427422b64564d5fb0be1940354bfe2e0529b18a9d9b8"
+checksum = "3b13c32d80ecc7ab747b80c3784bce54ee8a7a0cc4fbda9bf4cda2cf6fe90854"
 dependencies = [
  "backtrace",
 ]
@@ -124,9 +124,9 @@ checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
 
 [[package]]
 name = "async-trait"
-version = "0.1.70"
+version = "0.1.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79fa67157abdfd688a259b6648808757db9347af834624f27ec646da976aee5d"
+checksum = "a564d521dd56509c4c47480d00b80ee55f7e385ae48db5744c67ad50c92d2ebf"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -634,9 +634,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.3.10"
+version = "4.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "384e169cc618c613d5e3ca6404dda77a8685a63e08660dcc64abaf7da7cb0c7a"
+checksum = "3eab9e8ceb9afdade1ab3f0fd8dbce5b1b2f468ad653baf10e771781b2b67b73"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -645,9 +645,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.3.10"
+version = "4.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef137bbe35aab78bdb468ccfba75a5f4d8321ae011d34063770780545176af2d"
+checksum = "9f2763db829349bf00cfc06251268865ed4363b93a943174f638daf3ecdba2cd"
 dependencies = [
  "anstream",
  "anstyle",
@@ -657,9 +657,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.3.2"
+version = "4.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8cd2b2a819ad6eec39e8f1d6b53001af1e5469f8c177579cdaeb313115b825f"
+checksum = "54a9bb5758fc5dfe728d1019941681eccaf0cf8a4189b692a0ee2f2ecf90a050"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -697,9 +697,9 @@ checksum = "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa"
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.8"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03e69e28e9f7f77debdedbaafa2866e1de9ba56df55a8bd7cfc724c25a09987c"
+checksum = "a17b76ff3a4162b0b27f354a0c87015ddad39d35f9c0c36607a3bdd175dde1f1"
 dependencies = [
  "libc",
 ]
@@ -793,9 +793,9 @@ checksum = "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91"
 
 [[package]]
 name = "equivalent"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88bffebc5d80432c9b140ee17875ff173a8ab62faad5b257da912bd2f6c1c0a1"
+checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "errno"
@@ -1204,9 +1204,9 @@ dependencies = [
 
 [[package]]
 name = "is-terminal"
-version = "0.4.8"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24fddda5af7e54bf7da53067d6e802dbcc381d0a8eef629df528e3ebf68755cb"
+checksum = "cb0889898416213fab133e1d33a0e5858a48177452750691bde3666d0fdbaf8b"
 dependencies = [
  "hermit-abi",
  "rustix",
@@ -1215,9 +1215,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.8"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b02a5381cc465bd3041d84623d0fa3b66738b52b8e2fc3bab8ad63ab032f4a"
+checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
 
 [[package]]
 name = "js-sys"
@@ -1279,7 +1279,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
 dependencies = [
- "regex-automata",
+ "regex-automata 0.1.10",
 ]
 
 [[package]]
@@ -1519,9 +1519,9 @@ checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.63"
+version = "1.0.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b368fba921b0dce7e60f5e04ec15e565b3303972b42bcfde1d0713b881959eb"
+checksum = "92de25114670a878b1261c79c9f8f729fb97e95bac93f6312f583c60dd6a1dfe"
 dependencies = [
  "unicode-ident",
 ]
@@ -1538,9 +1538,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.29"
+version = "1.0.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "573015e8ab27661678357f27dc26460738fd2b6c86e46f386fde94cb5d913105"
+checksum = "5907a1b7c277254a8b15170f6e7c97cfa60ee7872a3217663bb81151e48184bb"
 dependencies = [
  "proc-macro2",
 ]
@@ -1586,13 +1586,14 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.8.4"
+version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0ab3ca65655bb1e41f2a8c8cd662eb4fb035e67c3f78da1d61dffe89d07300f"
+checksum = "b2eae68fc220f7cf2532e4494aded17545fce192d59cd996e0fe7887f4ceb575"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.7.2",
+ "regex-automata 0.3.3",
+ "regex-syntax 0.7.4",
 ]
 
 [[package]]
@@ -1605,6 +1606,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex-automata"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39354c10dd07468c2e73926b23bb9c2caca74c5501e38a35da70406f1d923310"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax 0.7.4",
+]
+
+[[package]]
 name = "regex-syntax"
 version = "0.6.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1612,9 +1624,9 @@ checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
-version = "0.7.2"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "436b050e76ed2903236f032a59761c1eb99e1b0aead2c257922771dab1fc8c78"
+checksum = "e5ea92a5b6195c6ef2a0295ea818b312502c6fc94dde986c5553242e18fd4ce2"
 
 [[package]]
 name = "retain_mut"
@@ -1670,9 +1682,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.2"
+version = "0.38.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aabcb0461ebd01d6b79945797c27f8529082226cb630a9865a71870ff63532a4"
+checksum = "0a962918ea88d644592894bc6dc55acc6c0956488adcebbfb6e273506b7fd6e5"
 dependencies = [
  "bitflags 2.3.3",
  "errno",
@@ -1716,9 +1728,9 @@ dependencies = [
 
 [[package]]
 name = "ryu"
-version = "1.0.14"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe232bdf6be8c8de797b22184ee71118d63780ea42ac85b61d1baa6d3b782ae9"
+checksum = "1ad4cc8da4ef723ed60bced201181d83791ad433213d8c24efffda1eec85d741"
 
 [[package]]
 name = "s3ite"
@@ -1872,24 +1884,24 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bebd363326d05ec3e2f532ab7660680f3b02130d780c299bca73469d521bc0ed"
+checksum = "b0293b4b29daaf487284529cc2f5675b8e57c61f70167ba415a463651fd6a918"
 
 [[package]]
 name = "serde"
-version = "1.0.166"
+version = "1.0.171"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d01b7404f9d441d3ad40e6a636a7782c377d2abdbe4fa2440e2edcc2f4f10db8"
+checksum = "30e27d1e4fd7659406c492fd6cfaf2066ba8773de45ca75e855590f856dc34a9"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.166"
+version = "1.0.171"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dd83d6dde2b6b2d466e14d9d1acce8816dedee94f735eac6395808b3483c6d6"
+checksum = "389894603bd18c46fa56231694f8d827779c0951a667087194cf9de94ed24682"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1898,9 +1910,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.100"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f1e14e89be7aa4c4b78bdbdc9eb5bf8517829a600ae8eaa39a6e1d960b5185c"
+checksum = "d03b412469450d4404fe8499a268edd7f8b79fecb074b0d812ad64ca21f4031b"
 dependencies = [
  "itoa",
  "ryu",
@@ -1921,9 +1933,9 @@ dependencies = [
 
 [[package]]
 name = "serde_yaml"
-version = "0.9.22"
+version = "0.9.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "452e67b9c20c37fa79df53201dc03839651086ed9bbe92b3ca585ca9fdaa7d85"
+checksum = "da6075b41c7e3b079e5f246eb6094a44850d3a4c25a67c581c80796c80134012"
 dependencies = [
  "indexmap 2.0.0",
  "itoa",
@@ -1989,9 +2001,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
+checksum = "62bb4feee49fdd9f707ef802e22365a35de4b7b299de4763d44bfea899442ff9"
 
 [[package]]
 name = "socket2"
@@ -2023,9 +2035,9 @@ checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
 
 [[package]]
 name = "syn"
-version = "2.0.23"
+version = "2.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59fb7d6d8281a51045d62b8eb3a7d1ce347b76f312af50cd3dc0af39c87c1737"
+checksum = "45c3457aacde3c65315de5031ec191ce46604304d2446e803d71ade03308d970"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2040,18 +2052,18 @@ checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
 
 [[package]]
 name = "thiserror"
-version = "1.0.41"
+version = "1.0.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c16a64ba9387ef3fdae4f9c1a7f07a0997fce91985c0336f1ddc1822b3b37802"
+checksum = "a35fc5b8971143ca348fa6df4f024d4d55264f3468c71ad1c2f365b0a4d58c42"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.41"
+version = "1.0.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d14928354b01c4d6a4f0e549069adef399a284e7995c7ccca94e8a07a5346c59"
+checksum = "463fe12d7993d3b327787537ce8dd4dfa058de32fc2b195ef3cde03dc4771e8f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2070,9 +2082,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.22"
+version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea9e1b3cf1243ae005d9e74085d4d542f3125458f3a81af210d901dcd7411efd"
+checksum = "59e399c068f43a5d116fedaf73b203fa4f9c519f17e2b34f63221d3792f81446"
 dependencies = [
  "itoa",
  "serde",
@@ -2088,9 +2100,9 @@ checksum = "7300fbefb4dadc1af235a9cef3737cea692a9d97e1b9cbcd4ebdae6f8868e6fb"
 
 [[package]]
 name = "time-macros"
-version = "0.2.9"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "372950940a5f07bf38dbe211d7283c9e6d7327df53794992d293e534c733d09b"
+checksum = "96ba15a897f3c86766b757e5ac7221554c6750054d74d5b28844fce5fb36a6c4"
 dependencies = [
  "time-core",
 ]
@@ -2331,9 +2343,9 @@ checksum = "92888ba5573ff080736b3648696b70cafad7d250551175acbaa4e0385b3e1460"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.10"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22049a19f4a68748a168c0fc439f9516686aa045927ff767eca0a85101fb6e73"
+checksum = "301abaae475aa91687eb82514b328ab47a211a533026cb25fc3e519b86adfc3c"
 
 [[package]]
 name = "unicode-normalization"
@@ -2346,9 +2358,9 @@ dependencies = [
 
 [[package]]
 name = "unsafe-libyaml"
-version = "0.2.8"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1865806a559042e51ab5414598446a5871b561d21b6764f2eabb0dd481d880a6"
+checksum = "f28467d3e1d3c6586d8f25fa243f544f5800fec42d97032474e17222c2b75cfa"
 
 [[package]]
 name = "untrusted"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,11 +14,11 @@ default = ["binary"]
 binary = ["tokio/full", "dep:clap", "dep:tracing-subscriber", "dep:hyper"]
 
 [dependencies]
-async-trait = "0.1.70"
+async-trait = "0.1.71"
 base64-simd = "0.8.0"
 bytes = "1.4.0"
 chrono = { version = "0.4.26", default-features = false, features = ["std", "clock"] }
-clap = { version = "4.3.10", optional = true, features = ["derive"] }
+clap = { version = "4.3.12", optional = true, features = ["derive"] }
 deadpool-sqlite = { version = "0.5.0", default-features = false, features = ["rt_tokio_1"] }
 rusqlite = { version = "0.28.0", features = ["time", "uuid", "bundled"] }
 futures = "0.3.28"
@@ -30,11 +30,11 @@ nugine-rust-utils = "0.3.1"
 numeric_cast = "0.2.1"
 path-absolutize = "3.1.0"
 s3s = "0.6.1"
-serde = { version = "1.0.166", features =["derive"] }
-serde_json = "1.0.100"
-serde_yaml = "0.9.22"
-thiserror = "1.0.41"
-time = "0.3.22"
+serde = { version = "1.0.171", features =["derive"] }
+serde_json = "1.0.103"
+serde_yaml = "0.9.23"
+thiserror = "1.0.43"
+time = "0.3.23"
 tokio = { version = "1.29.1", features = ["fs", "io-util"] }
 tokio-util = { version = "0.7.8", features = ["io"] }
 tower = { version = "0.4.13", features = ["full"] }
@@ -46,7 +46,7 @@ transform-stream = "0.3.0"
 uuid = { version = "1.4.0", features = ["v4"] }
 
 [dev-dependencies]
-anyhow = { version = "1.0.71", features = ["backtrace"] }
+anyhow = { version = "1.0.72", features = ["backtrace"] }
 aws-config = "0.55.3"
 aws-credential-types = { version = "0.55.3", features = ["test-util"] }
 aws-sdk-s3 = "0.28.0"

--- a/src/config.rs
+++ b/src/config.rs
@@ -138,6 +138,7 @@ impl Config {
             PRAGMA cache_size=-{};
             PRAGMA query_only={};
             PRAGMA foreign_keys=true;
+            PRAGMA auto_vacuum=INCREMENTAL;
         ",
             self.journal_mode(bucket),
             self.synchronous(bucket),

--- a/src/s3.rs
+++ b/src/s3.rs
@@ -156,7 +156,6 @@ impl S3 for Sqlite {
         req: S3Request<DeleteObjectInput>,
     ) -> S3Result<S3Response<DeleteObjectOutput>> {
         let DeleteObjectInput { bucket, key, .. } = req.input;
-
         let bucket_pool = self.try_get_bucket_pool(&bucket).await?;
 
         bucket_pool

--- a/src/s3.rs
+++ b/src/s3.rs
@@ -1,5 +1,3 @@
-use std::ops::Not;
-
 use crate::error::*;
 use crate::sqlite::ContinuationToken;
 use crate::sqlite::KeyValue;
@@ -9,6 +7,8 @@ use crate::utils::*;
 
 use bytes::Bytes;
 use futures::stream;
+use futures::TryStreamExt;
+use md5::{Digest, Md5};
 use s3s::dto::*;
 use s3s::s3_error;
 use s3s::S3Error;
@@ -17,12 +17,9 @@ use s3s::S3ErrorCode::InternalError;
 use s3s::S3Result;
 use s3s::S3;
 use s3s::{S3Request, S3Response};
+use std::ops::Not;
 use time::OffsetDateTime;
-
 use tokio::fs;
-
-use futures::TryStreamExt;
-use md5::{Digest, Md5};
 use tracing::debug;
 use uuid::Uuid;
 
@@ -450,102 +447,95 @@ impl S3 for Sqlite {
             ..
         } = req.input;
 
-        let max_keys = max_keys.unwrap_or(1000);
+        let max_keys = max_keys.unwrap_or(1000).clamp(0, 1000);
         let max_keys_usize = try_!(usize::try_from(max_keys));
-
-        let cotinuation_token_clone = continuation_token.clone();
-        let continuation_token = continuation_token
-            .map(|continuation_token| {
-                let continuation_tokens = self
-                    .continuation_tokens
-                    .read()
-                    .map_err(|err| S3Error::with_message(InternalError, err.to_string()))?;
-                match continuation_tokens.get(&continuation_token) {
-                    Some(continuation_token) => Ok(continuation_token.clone()),
-                    None => Err(s3_error!(InvalidToken)),
-                }
-            })
-            .transpose()?;
-
-        let prefix_clone = prefix.clone();
-        let start_after_clone = start_after.clone();
         let continuation_token_clone = continuation_token.clone();
 
-        let bucket_pool = self.try_get_bucket_pool(&bucket).await?;
-        let mut keys_values = bucket_pool
-            .interact(move |connection| {
-                let transaction = connection.transaction()?;
-                Self::try_list_objects(
-                    &transaction,
-                    prefix_clone,
-                    &start_after_clone,
-                    max_keys,
-                    &continuation_token_clone,
-                )
-            })
-            .await
-            .map_err(|err| S3Error::with_message(InternalError, err.to_string()))?
-            .map_err(|err| S3Error::with_message(InternalError, err.to_string()))?;
+        let (key_sizes, next_continuation_token) = match continuation_token {
+            // initial request requires taking a snapshot of the state of the database
+            None => {
+                let prefix_clone = prefix.clone();
+                let start_after_clone = start_after.clone();
+                let bucket_pool = self.try_get_bucket_pool(&bucket).await?;
+                let mut key_sizes = bucket_pool
+                    .interact(move |connection| {
+                        let transaction = connection.transaction()?;
+                        Self::try_list_objects(&transaction, &prefix_clone, &start_after_clone)
+                    })
+                    .await
+                    .map_err(|err| S3Error::with_message(InternalError, err.to_string()))?
+                    .map_err(|err| S3Error::with_message(InternalError, err.to_string()))?;
 
-        let is_truncated = keys_values.len() > max_keys_usize;
-        keys_values.truncate(max_keys_usize);
+                if key_sizes.len() <= max_keys_usize {
+                    (key_sizes, None)
+                } else {
+                    let remainder = key_sizes.split_off(max_keys_usize);
 
-        let objects = keys_values
+                    let mut continuation_tokens = self.continuation_tokens.lock().unwrap();
+                    let next_continuation_token = Uuid::new_v4().to_string();
+                    continuation_tokens.insert(
+                        next_continuation_token.clone(),
+                        ContinuationToken {
+                            token: next_continuation_token.clone(),
+                            last_modified: OffsetDateTime::now_utc(),
+                            key_sizes: remainder,
+                        },
+                    );
+
+                    (key_sizes, Some(next_continuation_token))
+                }
+            }
+            // subsequent request
+            Some(continuation_token) => {
+                let mut continuation_tokens = self.continuation_tokens.lock().unwrap();
+                let mut continuation_token = match continuation_tokens.remove(&continuation_token) {
+                    Some(continuation_token) => Ok(continuation_token),
+                    None => Err(s3_error!(InvalidToken)),
+                }?;
+
+                if continuation_token.key_sizes.len() <= max_keys_usize {
+                    (continuation_token.key_sizes, None)
+                } else {
+                    let remainder = continuation_token.key_sizes.split_off(max_keys_usize);
+                    let key_sizes = std::mem::replace(&mut continuation_token.key_sizes, remainder);
+
+                    let continuation_token_clone = continuation_token.token.clone();
+                    continuation_token.last_modified = OffsetDateTime::now_utc();
+                    continuation_tokens
+                        .insert(continuation_token_clone.clone(), continuation_token);
+
+                    (key_sizes, Some(continuation_token_clone))
+                }
+            }
+        };
+
+        let objects = key_sizes
             .into_iter()
-            .map(|object| {
+            .map(|key_size| {
                 Ok(Object {
-                    key: Some(object.key),
-                    last_modified: Some(object.last_modified.into()),
-                    size: i64::try_from(object.size)?,
+                    key: Some(key_size.key),
+                    last_modified: Some(key_size.last_modified.into()),
+                    size: i64::try_from(key_size.size)?,
+                    e_tag: Some(key_size.md5),
                     ..Default::default()
                 })
             })
             .collect::<Result<Vec<_>>>()?;
-
-        let continuation_token = {
-            let mut continuation_tokens = self
-                .continuation_tokens
-                .write()
-                .map_err(|err| S3Error::with_message(InternalError, err.to_string()))?;
-
-            // clean up old tokens
-            continuation_tokens.retain(|_, value| {
-                (OffsetDateTime::now_utc() - value.last_modified).as_seconds_f32() < 300.0
-            });
-
-            let continuation_token = is_truncated.then(|| {
-                let (token, mut offset) = continuation_token
-                    .map_or((Uuid::new_v4().to_string(), 0), |continuation_token| {
-                        (continuation_token.token, continuation_token.offset)
-                    });
-                offset += max_keys_usize;
-                let continuation_token = ContinuationToken {
-                    token: token.clone(),
-                    last_modified: OffsetDateTime::now_utc(),
-                    offset,
-                };
-                continuation_tokens.insert(token, continuation_token.clone());
-                continuation_token
-            });
-
-            Result::<_, S3Error>::Ok(continuation_token)
-        }?;
 
         let key_count = try_!(i32::try_from(objects.len()));
 
         let output = ListObjectsV2Output {
             key_count,
             max_keys,
-            continuation_token: cotinuation_token_clone,
-            is_truncated,
+            continuation_token: continuation_token_clone,
+            is_truncated: next_continuation_token.is_some(),
             contents: Some(objects),
             delimiter,
             encoding_type,
             name: Some(bucket),
             prefix,
             start_after,
-            next_continuation_token: continuation_token
-                .map(|continuation_token| continuation_token.token),
+            next_continuation_token,
             ..Default::default()
         };
 


### PR DESCRIPTION
## Changed

- Split the core data table into `data` and `metadata`.
- Add a simple garbage collection task to clean up any redundant state. E.g. from a client cancelling an in-progress `list_objects` task.
- Remove SQLite `VACUUM` command on startup due to potentially large memory usage.

### Fixed

- Snapshot database `metadata` state on `list_objects` so that deletes will remove all objects.